### PR TITLE
Turn AppStream validation errors into mere warnings

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -824,7 +824,7 @@ main (int argc, char *argv[])
                     g_print("In case of issues, please refer to https://github.com/ximion/appstream\n");
                     int ret = run_external(g_find_program_in_path ("appstreamcli"), args);
                     if (ret != 0)
-                        die("Failed to validate AppStream information with appstreamcli");
+                        g_print("WARNING: Failed to validate AppStream information with appstreamcli");
                 }
                 /* It seems that hughsie's appstream-util does additional validations */
                 if(g_find_program_in_path ("appstream-util")) {
@@ -838,7 +838,7 @@ main (int argc, char *argv[])
                     g_print("In case of issues, please refer to https://github.com/hughsie/appstream-glib\n");
                     int ret = run_external(g_find_program_in_path ("appstream-util"), args);
                     if (ret != 0)
-                        die("Failed to validate AppStream information with appstream-util");
+                        g_print("WARNING: Failed to validate AppStream information with appstream-util");
                 }
             }
         }


### PR DESCRIPTION
Recent versions of AppStream validation tools now want to enforce that you use something like `org.appimage.appimagetool.desktop` instead of `appimagetool.desktop`, even though the former is way simpler and works perfectly fine for our use case.

Since AppStream validation tools are constantly changing and with them the rules are a moving target, it's almost impossible to support AppStream for the long run without constantly fiddling around.

As a result, we might consider to make AppStream validation errors just non-fatal warnings.