### PR TITLE
Add APPIMAGETOOL_APP_NAME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Application Options:
 Some of the parameters above can alternatively be specified as environment variables. Also, some additional environment variables are available, too.
 
 - `ARCH`: Needs to be set whenever appimagetool cannot automatically determine the architecture of the binaries inside the AppDir to choose a suitable runtime (e.g., when binaries for multiple architectures or just shell scripts are contained in there).
+- `APPIMAGETOOL_APP_NAME`: If no destination is set by the user, appimagetool automatically generates a suitable output filename, using the root desktop entry's `Name` field. With this environment variable, this value can be set explicitly by the user.
 - `APPIMAGETOOL_FORCE_SIGN`: By default, if signing fails, appimagetool just logs a warning but will not abort immediately. If this environment variable is set, appimagetool exits with a non-zero return code.
 - `APPIMAGETOOL_SIGN_PASSPHRASE`: If the `--sign-key` is encrypted and requires a passphrase to be used for signing (and, for some reason, GnuPG cannot be used interactively, e.g., in a CI environment), this environment variable can be used to safely pass the key.
 - `VERSION`: This value will be inserted by appimagetool into the root desktop file and (if the destination parameter is not provided by the user) in the output filename.

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -726,11 +726,21 @@ main (int argc, char *argv[])
         fprintf(stderr, "Using architecture %s\n", arch);
 
         char app_name_for_filename[PATH_MAX];
-        sprintf(app_name_for_filename, "%s", get_desktop_entry(kf, "Name"));
-        replacestr(app_name_for_filename, " ", "_");
-        
-        if(verbose)
-            fprintf (stderr,"App name for filename: %s\n", app_name_for_filename);
+        {
+            const char* const env_app_name = getenv("APPIMAGETOOL_APP_NAME");
+            if (env_app_name != NULL) {
+                fprintf(stderr, "Using user-specified app name: %s\n", env_app_name);
+                strncpy(app_name_for_filename, env_app_name, PATH_MAX);
+            } else {
+                const gchar* const desktop_file_app_name = get_desktop_entry(kf, "Name");
+                sprintf(app_name_for_filename, "%s", desktop_file_app_name);
+                replacestr(app_name_for_filename, " ", "_");
+
+                if (verbose) {
+                    fprintf(stderr, "Using app name extracted from desktop file: %s\n", app_name_for_filename);
+                }
+            }
+        }
         
         if (remaining_args[1]) {
             destination = remaining_args[1];


### PR DESCRIPTION
Allows using the output name generation appimagetool provides with desktop files whose `Name` entry is unsuitable for the purpose. Users can specify their own prefix with this new environment variable.

*Based on #17, please **do not merge** but only approve if it works for you.* You can find the diff to the other branch here: https://github.com/AppImage/appimagetool/compare/document-env-vars...app-name-prefix?expand=1