### PR TITLE
Implement certificate lookup, closes #24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cmake-build-*/
 *.*swp*
 *.bak
 *.AppImage*
+squashfs-root/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Some of the parameters above can alternatively be specified as environment varia
 - `APPIMAGETOOL_FORCE_SIGN`: By default, if signing fails, appimagetool just logs a warning but will not abort immediately. If this environment variable is set, appimagetool exits with a non-zero return code.
 - `APPIMAGETOOL_SIGN_PASSPHRASE`: If the `--sign-key` is encrypted and requires a passphrase to be used for signing (and, for some reason, GnuPG cannot be used interactively, e.g., in a CI environment), this environment variable can be used to safely pass the key.
 - `VERSION`: This value will be inserted by appimagetool into the root desktop file and (if the destination parameter is not provided by the user) in the output filename.
+- `APPIMAGETOOL_FETCH_RUNTIME_INSECURE`: If set, CA certificates will not be used when downloading the runtime. 
 - `SSL_CERT_FILE`: If set, CA certificates will be looked up in this file when downloading the runtime.
 - `SSL_CERT_DIR`: If set, CA certificates will be looked up in this directory when downloading the runtime.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Some of the parameters above can alternatively be specified as environment varia
 - `APPIMAGETOOL_FORCE_SIGN`: By default, if signing fails, appimagetool just logs a warning but will not abort immediately. If this environment variable is set, appimagetool exits with a non-zero return code.
 - `APPIMAGETOOL_SIGN_PASSPHRASE`: If the `--sign-key` is encrypted and requires a passphrase to be used for signing (and, for some reason, GnuPG cannot be used interactively, e.g., in a CI environment), this environment variable can be used to safely pass the key.
 - `VERSION`: This value will be inserted by appimagetool into the root desktop file and (if the destination parameter is not provided by the user) in the output filename.
+- `SSL_CERT_FILE`: If set, CA certificates will be looked up in this file when downloading the runtime.
+- `SSL_CERT_DIR`: If set, CA certificates will be looked up in this directory when downloading the runtime.
 
 ## Building
 

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -880,6 +880,9 @@ main (int argc, char *argv[])
         if (verbose)
             printf("Size of the embedded runtime: %d bytes\n", size);
         
+        if (verbose)
+            printf("Destination: %s\n", destination);
+
         int result = sfs_mksquashfs(source, destination, size);
         if(result != 0)
             die("sfs_mksquashfs error");

--- a/src/appimagetool_fetch_runtime.c
+++ b/src/appimagetool_fetch_runtime.c
@@ -103,7 +103,6 @@ bool fetch_runtime(char* arch, size_t* size, char** buffer, bool verbose) {
     // the GET request, too
     // we store the URL we are redirected to (which probably lies on some AWS and is unique to that file) for use in
     // the GET request, which should ensure we really download the file whose size we check now
-    handle = curl_easy_init();
     
     if (handle == NULL) {
         fprintf(stderr, "Failed to initialize libcurl\n");
@@ -151,9 +150,6 @@ bool fetch_runtime(char* arch, size_t* size, char** buffer, bool verbose) {
         fprintf(stderr, "HEAD request to %s failed: %s\n", url, curl_error_buf);
     }
 
-    curl_easy_cleanup(handle);
-    handle = NULL;
-
     if (success != CURLE_OK || strlen(effective_url) == 0 || content_length <= 0) {
         curl_global_cleanup();
         return false;
@@ -170,8 +166,6 @@ bool fetch_runtime(char* arch, size_t* size, char** buffer, bool verbose) {
         curl_global_cleanup();
         return false;
     }
-
-    handle = curl_easy_init();
 
     if (handle == NULL) {
         fprintf(stderr, "Failed to initialize libcurl\n");

--- a/src/appimagetool_fetch_runtime.c
+++ b/src/appimagetool_fetch_runtime.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
 #include <malloc.h>
@@ -13,6 +14,57 @@
 bool fetch_runtime(char* arch, size_t* size, char** buffer, bool verbose) {
     // not the cleanest approach to globally init curl here, but this method shouldn't be called more than once anyway
     curl_global_init(CURL_GLOBAL_ALL);
+    CURL* handle = curl_easy_init();
+
+    if (handle == NULL) {
+        fprintf(stderr, "Failed to initialize libcurl\n");
+        curl_global_cleanup();
+        return false;
+    }
+
+    // use SSL_CERT_FILE and/or SSL_CERT_DIR if set, otherwise check for common locations
+    // https://curl.haxx.se/docs/sslcerts.html
+    // https://gitlab.com/probono/platformissues#certificates
+    // https://go.dev/src/crypto/x509/root_linux.go
+    if (getenv("SSL_CERT_FILE") != NULL) {
+        if (curl_easy_setopt(handle, CURLOPT_CAINFO, getenv("SSL_CERT_FILE")) == CURLE_OK) {
+            fprintf(stderr, "Using certificate file %s\n", getenv("SSL_CERT_FILE"));
+        }
+    } else {
+        const char* certFiles[] = {
+        "/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+        "/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+        "/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+        "/etc/pki/tls/cacert.pem",                           // OpenELEC
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+        "/etc/ssl/cert.pem",                                 // Alpine Linux
+        };
+        for (size_t i = 0; i < sizeof(certFiles) / sizeof(certFiles[0]); ++i) {
+            if (curl_easy_setopt(handle, CURLOPT_CAINFO, certFiles[i]) == CURLE_OK) {
+                fprintf(stderr, "Using certificate file %s\n", certFiles[i]);
+                break;
+            }
+        }
+    }
+
+    if (getenv("SSL_CERT_DIR") != NULL) {
+        if (curl_easy_setopt(handle, CURLOPT_CAPATH, getenv("SSL_CERT_DIR")) == CURLE_OK) {
+            fprintf(stderr, "Using certificate directory %s\n", getenv("SSL_CERT_DIR"));
+        }
+    } else {
+        const char* certDirectories[] = {
+            "/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
+            "/etc/pki/tls/certs",           // Fedora/RHEL
+            "/system/etc/security/cacerts", // Android
+        };
+
+        for (size_t i = 0; i < sizeof(certDirectories) / sizeof(certDirectories[0]); ++i) {
+            if (curl_easy_setopt(handle, CURLOPT_CAPATH, certDirectories[i]) == CURLE_OK) {
+                fprintf(stderr, "Using certificate directory %s\n", certDirectories[i]);
+                break;
+            }
+        }
+    }
 
     // should be plenty big for the URL
     char url[1024];
@@ -26,7 +78,7 @@ bool fetch_runtime(char* arch, size_t* size, char** buffer, bool verbose) {
     fprintf(stderr, "Downloading runtime file from %s\n", url);
 
     char curl_error_buf[CURL_ERROR_SIZE];
-    CURL* handle = NULL;
+
     // should also be plenty big for the redirect target
     char effective_url[sizeof(url)];
     int success = -1L;


### PR DESCRIPTION
Tested on openSUSE.

* Use `SSL_CERT_FILE` and/or `SSL_CERT_DIR` environment variables if set, otherwise check for common locations
* Do not check certificates if `APPIMAGETOOL_FETCH_RUNTIME_INSECURE` is set

References:
* https://curl.haxx.se/docs/sslcerts.html
* https://gitlab.com/probono/platformissues#certificates
* https://go.dev/src/crypto/x509/root_linux.go