### PR TITLE
Try to use system-provided CA certificate bundles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 project(appimagetool)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # determine Git version based on distance to tag
 # FIXME: right now we have no tags, so we just use the current Git commit's hash

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -876,7 +876,11 @@ main (int argc, char *argv[])
             }
         } else {
             if (!fetch_runtime(arch, &size, &data, verbose)) {
-                die("Failed to download runtime file");
+                die(
+                    "Failed to download runtime file, please download the runtime manually from"
+                    "https://github.com/AppImage/type2-runtime/releases and pass it to appimagetool with"
+                    "--runtime-file"
+                );
             }
         }
         if (verbose)


### PR DESCRIPTION
Fixes #24. Replaces #29.

This PR bumps the C++ standard requirement to C++20 so we can use `std::array` more easily.