### PR TITLE
Download classic runtime by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Some of the parameters above can alternatively be specified as environment varia
 - `APPIMAGETOOL_FORCE_SIGN`: By default, if signing fails, appimagetool just logs a warning but will not abort immediately. If this environment variable is set, appimagetool exits with a non-zero return code.
 - `APPIMAGETOOL_SIGN_PASSPHRASE`: If the `--sign-key` is encrypted and requires a passphrase to be used for signing (and, for some reason, GnuPG cannot be used interactively, e.g., in a CI environment), this environment variable can be used to safely pass the key.
 - `VERSION`: This value will be inserted by appimagetool into the root desktop file and (if the destination parameter is not provided by the user) in the output filename.
+- `DOWNLOAD_STATIC_RUNTIME`: Download new, experimental and [statically linked runtime](https://github.com/AppImage/type2-runtime) instead of the [classic runtime](https://github.com/AppImage/AppImageKit). 
 
 ## Building
 

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -875,7 +875,16 @@ main (int argc, char *argv[])
                 die("Unable to load provided runtime file");
             }
         } else {
-            if (!fetch_runtime(arch, &size, &data, verbose)) {
+            RuntimeType runtimeType = RUNTIME_TYPE_CLASSIC;
+
+            if (getenv("DOWNLOAD_STATIC_RUNTIME") != NULL) {
+                fprintf(stderr, "Downloading static runtime\n");
+                runtimeType = RUNTIME_TYPE_STATIC;
+            } else {
+                fprintf(stderr, "Downloading classic runtime\n");
+            }
+
+            if (!fetch_runtime(arch, &size, &data, runtimeType, verbose)) {
                 die(
                     "Failed to download runtime file, please download the runtime manually from"
                     "https://github.com/AppImage/type2-runtime/releases and pass it to appimagetool with"

--- a/src/appimagetool_fetch_runtime.cpp
+++ b/src/appimagetool_fetch_runtime.cpp
@@ -230,9 +230,16 @@ public:
     }
 };
 
-bool fetch_runtime(char *arch, size_t *size, char **buffer, bool verbose) {
+bool fetch_runtime(char *arch, size_t *size, char **buffer, RuntimeType runtimeType, bool verbose) {
     std::ostringstream urlstream;
-    urlstream << "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-" << arch;
+    switch (runtimeType) {
+        case RUNTIME_TYPE_CLASSIC:
+            urlstream << "https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-" << arch;
+            break;
+        case RUNTIME_TYPE_STATIC:
+            urlstream << "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-" << arch;
+            break;
+    }
     auto url = urlstream.str();
 
     std::cerr << "Downloading runtime file from " << url << std::endl;

--- a/src/appimagetool_fetch_runtime.h
+++ b/src/appimagetool_fetch_runtime.h
@@ -7,7 +7,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-bool fetch_runtime(char *arch, size_t *size, char **buffer, bool verbose);
+
+typedef enum {
+    RUNTIME_TYPE_CLASSIC,
+    RUNTIME_TYPE_STATIC,
+} RuntimeType;
+
+bool fetch_runtime(char *arch, size_t *size, char **buffer, RuntimeType runtimeType, bool verbose);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The static runtime is still considered experimental and not nearly as battle-tested as the "classic" variant from AppImageKit.

For users who wish to download the static variant instead, an environment variable was added which changes the new default behavior.

This commit allows me to use this new appimagetool in linuxdeploy-plugin-appimage, which would serve as a field test for the tool itself. I do not want to make people use the static variant until it is fully compatible with everything and the specification changes have been made.