### PR TITLE
Fix detection of usable CA certificate bundle

### DIFF
--- a/ci/build-in-docker.sh
+++ b/ci/build-in-docker.sh
@@ -31,8 +31,7 @@ case "$ARCH" in
 esac
 
 # libassuan-static is supported only from 3.19 onwards
-# TODO: change this to a stable release once Alpine 3.19 was released
-image="$image_prefix"/alpine:edge
+image="$image_prefix"/alpine:3.19
 
 repo_root="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")"/..)"
 

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -877,8 +877,8 @@ main (int argc, char *argv[])
         } else {
             if (!fetch_runtime(arch, &size, &data, verbose)) {
                 die(
-                    "Failed to download runtime file, please download the runtime manually from"
-                    "https://github.com/AppImage/type2-runtime/releases and pass it to appimagetool with"
+                    "Failed to download runtime file, please download the runtime manually from "
+                    "https://github.com/AppImage/type2-runtime/releases and pass it to appimagetool with "
                     "--runtime-file"
                 );
             }

--- a/src/appimagetool_fetch_runtime.cpp
+++ b/src/appimagetool_fetch_runtime.cpp
@@ -140,7 +140,7 @@ private:
 #if querying_supported
         {
             const auto caInfo = getOption<char*>(CURLINFO_CAINFO);
-            if (std::filesystem::exists(caInfo)) {
+            if (caInfo != nullptr && std::filesystem::exists(caInfo)) {
                 if (verbose) {
                     std::cerr << "libcurl's default CA certificate bundle file " << caInfo << " was found on this system" << std::endl;
                 }
@@ -150,7 +150,7 @@ private:
 
         {
             const auto caPath = getOption<char*>(CURLINFO_CAPATH);
-            if (std::filesystem::is_directory(caPath)) {
+            if (caPath != nullptr && std::filesystem::is_directory(caPath)) {
                 if (verbose) {
                     std::cerr << "libcurl's default CA certificate bundle directory " << caPath
                               << " was found on this system" << std::endl;


### PR DESCRIPTION
Fixes segfaults in #34.

Also pins Alpine Docker image version to fix build issues due to the previous use of the bleeding `edge` tag.