### PR TITLE
Added missing include

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <gio/gio.h>
 
 #include <stdio.h>


### PR DESCRIPTION
g_unlink() needs glib/gstdio.h to be included.