### PR TITLE
Also allow ARCH=aarch64

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -1,6 +1,6 @@
 /**************************************************************************
  * 
- * Copyright (c) 2004-23 Simon Peter
+ * Copyright (c) 2004-24 Simon Peter
  * 
  * All Rights Reserved.
  * 
@@ -366,7 +366,8 @@ void extract_arch_from_text(gchar *archname, const gchar* sourcename, bool* arch
                 archs[fARCH_armhf] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM\n", sourcename);
-            } else if (g_ascii_strncasecmp("arm_aarch64", archname, 20) == 0) {
+            } else if (g_ascii_strncasecmp("arm_aarch64", archname, 20) == 0 ||
+                       g_ascii_strncasecmp("aarch64", archname, 20) == 0) {
                 archs[fARCH_aarch64] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM aarch64\n", sourcename);


### PR DESCRIPTION
Should solve https://github.com/AppImage/AppImageKit/issues/1163

Currently `ARCH=aarch64` fails but `ARCH=arm_aarch64` works.

The first "a" in "aarch64" already stands for "ARM", so there should be no non-ARM aarch64.

So we shoud make  `ARCH=aarch64` work as expected. Leaving `ARCH=arm_aarch64` so as to not break legacy code that relies on it.