### PR TITLE
Update name of runtime to be downloaded

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -52,6 +52,6 @@ popd
 find AppDir
 cat AppDir/appimagetool.desktop
 
-AppDir/AppRun --runtime-file runtime-"$ARCH" AppDir
+AppDir/AppRun ---file runtime-fuse3-"$ARCH" AppDir
 
 mv appimagetool-*.AppImage "$old_cwd"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -52,6 +52,6 @@ popd
 find AppDir
 cat AppDir/appimagetool.desktop
 
-AppDir/AppRun ---file runtime-fuse3-"$ARCH" AppDir
+AppDir/AppRun --runtime-file runtime-fuse3-"$ARCH" AppDir
 
 mv appimagetool-*.AppImage "$old_cwd"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -41,7 +41,7 @@ cp "$(which mksquashfs)" AppDir/usr/bin
 cp "$repo_root"/resources/AppRun.sh AppDir/AppRun
 chmod +x AppDir/AppRun
 
-wget https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-"$ARCH"
+wget https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-fuse3-"$ARCH"
 
 pushd AppDir
 ln -s usr/share/applications/appimagetool.desktop .

--- a/src/appimagetool_fetch_runtime.cpp
+++ b/src/appimagetool_fetch_runtime.cpp
@@ -247,7 +247,7 @@ public:
 
 bool fetch_runtime(char *arch, size_t *size, char **buffer, bool verbose) {
     std::ostringstream urlstream;
-    urlstream << "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-" << arch;
+    urlstream << "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-fuse3-" << arch;
     auto url = urlstream.str();
 
     std::cerr << "Downloading runtime file from " << url << std::endl;


### PR DESCRIPTION
Quick fix to partly address https://github.com/AppImage/appimagetool/issues/58.

The real reason, I think, is to not use the downloading mechanism as it is way too fragile:
* The repo name might change
* The filename might change

Errors caused by this should happen at _build_ time, when developers can fix it, rather than at _run_ time, when users are affected.

The bare minimum needed, I think, is that changes in type2-runtime need to trigger a build of appimagetool. So that any potential issues are seen by developers immediately.