### PR TITLE
Revert "Update name of runtime to be downloaded"

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -41,7 +41,7 @@ cp "$(which mksquashfs)" AppDir/usr/bin
 cp "$repo_root"/resources/AppRun.sh AppDir/AppRun
 chmod +x AppDir/AppRun
 
-wget https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-fuse3-"$ARCH"
+wget https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-"$ARCH"
 
 pushd AppDir
 ln -s usr/share/applications/appimagetool.desktop .
@@ -52,6 +52,6 @@ popd
 find AppDir
 cat AppDir/appimagetool.desktop
 
-AppDir/AppRun --runtime-file runtime-fuse3-"$ARCH" AppDir
+AppDir/AppRun --runtime-file runtime-"$ARCH" AppDir
 
 mv appimagetool-*.AppImage "$old_cwd"

--- a/src/appimagetool_fetch_runtime.cpp
+++ b/src/appimagetool_fetch_runtime.cpp
@@ -247,7 +247,7 @@ public:
 
 bool fetch_runtime(char *arch, size_t *size, char **buffer, bool verbose) {
     std::ostringstream urlstream;
-    urlstream << "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-fuse3-" << arch;
+    urlstream << "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-" << arch;
     auto url = urlstream.str();
 
     std::cerr << "Downloading runtime file from " << url << std::endl;


### PR DESCRIPTION
Reverts AppImage/appimagetool#59 because the name of the runtime was renamed to its original name in https://github.com/AppImage/type2-runtime/pull/57 again