### PR TITLE
Use default block size with zstd compression

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -156,12 +156,13 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
             args[i++] = "16384";
         } else if (strcmp(sqfs_comp, "zstd") == 0) {
             /*
-             * > Build with 1MiB block size
-             * > Using a bigger block size than mksquashfs's default improves read speed and can produce smaller AppImages as well
-             * -- https://github.com/probonopd/go-appimage/commit/c4a112e32e8c2c02d1d388c8fa45a9222a529af3
+             * > Build with default 128K block size
+             * > It used to be 1M but that actually causes much higher startup times.
+             * > Some testing might be needed to see if there is some other value that actually improves performance.
+             * -- https://github.com/AppImage/appimagetool/issues/64
              */
             args[i++] = "-b";
-            args[i++] = "1M";
+            args[i++] = "128K";
         }
 
         // check if ignore file exists and use it if possible


### PR DESCRIPTION
Indeed this was the problem, I just tested making an appimage with this appimagetool and I no longer have the issue of higher startup time. 

![image](https://github.com/user-attachments/assets/eca5681d-94a4-41c7-94f5-b94c22b5af32)

Fixes #64 

Build if someone wants to replicate my benchmarks: https://github.com/Samueru-sama/appimagetool/releases