### PR TITLE
Do not mark continuous as "prerelease"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,4 @@ jobs:
         run: |
           wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
           chmod +x pyuploadtool-x86_64.AppImage
-          ./pyuploadtool-x86_64.AppImage **/appimagetool*.AppImage*
+          GITHUB_CONTINUOUS_RELEASE_TYPE=stable ./pyuploadtool-x86_64.AppImage **/appimagetool*.AppImage*


### PR DESCRIPTION
So far, pyuploadtool was marking the continuous release as "prerelease", resulting it in being hidden here:

![image](https://github.com/user-attachments/assets/b87a50b8-e43d-4a82-a9fd-6b2c1349a924)

This has led to confusion, as people thought there is "no recent release". In fact, continuous is always the only supported release as I have no capacity to even look at bugs filed against anything else but the latest continuous release.

With this change, the release will still be called "continuous" but will have the visibility it needs (instead of some "old" release which is no longer supported).