### PR TITLE
Fix compilation error and warning

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -913,7 +913,7 @@ main (int argc, char *argv[])
             }
         }
         if (verbose)
-            printf("Size of the embedded runtime: %d bytes\n", size);
+            printf("Size of the embedded runtime: %zu bytes\n", size);
         
         int result = sfs_mksquashfs(source, destination, size);
         if(result != 0)

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -949,7 +949,7 @@ main (int argc, char *argv[])
                     if(zsyncmake_path){
                         char buf[1024];
                         // gh-releases-zsync|probono|AppImages|latest|Subsurface-*x86_64.AppImage.zsync
-                        int ret = snprintf(buf, "gh-releases-zsync|%s|%s|latest|%s*-%s.AppImage.zsync", github_repository_owner, github_repository_name, app_name_for_filename, arch);
+                        int ret = snprintf(buf, sizeof(buf), "gh-releases-zsync|%s|%s|latest|%s*-%s.AppImage.zsync", github_repository_owner, github_repository_name, app_name_for_filename, arch);
                         if (ret < 0) {
                             die("snprintf error");
                         } else if (ret >= sizeof(buf)) {


### PR DESCRIPTION
Two minor commits:
* The first one fixes a compilation error due to a missing `sizeof(buf)` in a snprintf argument list.
* The second ones fixes a compiler warning, where a %d was used instead of %zu to print a size_t typed variable.