### PR TITLE
fix option passing to mksquashfs

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -195,7 +195,11 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         }
 
         for (guint sqfs_opts_idx = 0; sqfs_opts_idx < sqfs_opts_len; ++sqfs_opts_idx) {
-            args[i++] = sqfs_opts[sqfs_opts_idx];
+            gchar** split_opts = g_strsplit(sqfs_opts[sqfs_opts_idx], " ", 0);
+            guint j = 0;
+            while (split_opts[j] != NULL) {
+                args[i++] = split_opts[j++];
+            }
         }
 
         args[i++] = 0;


### PR DESCRIPTION
options passed to mksquashfs can take the form

`--mksquashfs-opt "-processors 2"`

Currently the code is passing this two-word option as a single arg to mksquashfs, which doesn't work.
This is a minor fix to split such options on space, and pass them as multiple words.

