### PR TITLE
First call readlink on argument 0 and then dirname to fix support when executed via a symbolic link

### DIFF
--- a/resources/AppRun.sh
+++ b/resources/AppRun.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-this_dir="$(readlink -f "$(dirname "$0")")"
+this_dir="$(dirname -- "$(readlink -f -- "$0")")"
 
 # make appimagetool prefer the bundled mksquashfs
 export PATH="$this_dir"/usr/bin:"$PATH"


### PR DESCRIPTION
Fixes #109