### PR TITLE
Lengthen string comparisons for arch names, so as to not skip arm_aarch64

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -351,29 +351,29 @@ void extract_arch_from_text(gchar *archname, const gchar* sourcename, bool* arch
         if (archname) {
             replacestr(archname, "-", "_");
             replacestr(archname, " ", "_");
-            if (g_ascii_strncasecmp("i386", archname, 4) == 0
-                    || g_ascii_strncasecmp("i486", archname, 4) == 0
-                    || g_ascii_strncasecmp("i586", archname, 4) == 0
-                    || g_ascii_strncasecmp("i686", archname, 4) == 0
-                    || g_ascii_strncasecmp("intel_80386", archname, 11) == 0
-                    || g_ascii_strncasecmp("intel_80486", archname, 11) == 0
-                    || g_ascii_strncasecmp("intel_80586", archname, 11) == 0
-                    || g_ascii_strncasecmp("intel_80686", archname, 11) == 0
+            if (g_ascii_strncasecmp("i386", archname, 5) == 0
+                    || g_ascii_strncasecmp("i486", archname, 5) == 0
+                    || g_ascii_strncasecmp("i586", archname, 5) == 0
+                    || g_ascii_strncasecmp("i686", archname, 5) == 0
+                    || g_ascii_strncasecmp("intel_80386", archname, 12) == 0
+                    || g_ascii_strncasecmp("intel_80486", archname, 12) == 0
+                    || g_ascii_strncasecmp("intel_80586", archname, 12) == 0
+                    || g_ascii_strncasecmp("intel_80686", archname, 12) == 0
                     ) {
                 archs[fARCH_i686] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture i386\n", sourcename);
-            } else if (g_ascii_strncasecmp("x86_64", archname, 6) == 0) {
+            } else if (g_ascii_strncasecmp("x86_64", archname, 7) == 0) {
                 archs[fARCH_x86_64] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture x86_64\n", sourcename);
-            } else if (g_ascii_strncasecmp("arm", archname, 3) == 0 ||
-                       g_ascii_strncasecmp("armhf", archname, 5) == 0) {
+            } else if (g_ascii_strncasecmp("arm", archname, 4) == 0 ||
+                       g_ascii_strncasecmp("armhf", archname, 6) == 0) {
                 archs[fARCH_armhf] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM\n", sourcename);
-            } else if (g_ascii_strncasecmp("arm_aarch64", archname, 11) == 0 ||
-                       g_ascii_strncasecmp("aarch64", archname, 7) == 0) {
+            } else if (g_ascii_strncasecmp("arm_aarch64", archname, 12) == 0 ||
+                       g_ascii_strncasecmp("aarch64", archname, 8) == 0) {
                 archs[fARCH_aarch64] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM aarch64\n", sourcename);


### PR DESCRIPTION
### Context

See #115.
(Fixes: #115)

### Explanation

~~Strings starting with "arm[...?]" should not be checked before strings starting with "arm_aarch64[...?]", since the former will prematurely match, preventing the latter from ever matching.~~

_[EDIT: a variant of one of the alternate solutions below was used instead.]_

### Available Alternate Solutions

~~Alternatively, the longer max comparison character count could be restored (was 20 chars before #114), so that the comparison is more "exact match" rather than "starts with," per documentation of this comparison function: https://docs.gtk.org/glib/func.ascii_strncasecmp.html. (I tested this and it works. I don't have a strong preference but I simply picked one of the available solutions to get a PR out quickly for your consideration.)~~

_[EDIT: Lengthened all of the string comparisons to "the fixed string's non-null ASCII character count + 1" bytes, to include the fixed string's terminating NUL byte, so as to remove ambiguities between longer strings and shorter substrings that could otherwise be matched at the beginnings of those fixed strings. Particularly addresses the fact that the first three characters of "arm" == the first three characters of "arm_arch64" (bug).]_

~~We could drop the check for the "arm" string entirely, which it seems may have been the intended solution in the review discussions of #114, but I'm not sure if anyone's scripts out there use that, or what, it would have been harder for me to verify that approach doesn't break anyone's stuff so I opted for this that doesn't remove any string checks, only reorders them.~~

~~There are likely even more solutions to the problem... But this PR is a simple one, and works for me in testing.~~

### Verification Process

I ran a CI workflow with and without this change.

- With this change, the `aarch64`runtime is correctly used. CI workflow that needs this passes.
  - ~~https://cirrus-ci.com/task/4607957775679488?logs=fix_linux_appimage#L8194~~
  - _\[EDIT: Updated solution **also** behaves correctly in CI: https://cirrus-ci.com/task/6069624871059456?logs=fix_linux_appimage#L8194 \]_
- Without this change, the `armhf` runtime is erroneously used. CI workflow errors due to `cannot execute binary file: Exec format error`.
  - https://cirrus-ci.com/task/4806848068452352?logs=fix_linux_appimage#L8189

That shows some change from current `main` branch is indeed needed, and that this PR does indeed work as a fix.